### PR TITLE
remove TAU, TWO_PI

### DIFF
--- a/generators/sculpt.js
+++ b/generators/sculpt.js
@@ -199,7 +199,6 @@ export function replaceMathOps(codeSrc) {
 export function sculptToGLSL(userProvidedSrc) {
 	const PI = Math.PI;
 	const TWO_PI = Math.PI * 2;
-	const TAU = TWO_PI;
 	
 	let debug = false;
 	userProvidedSrc = replaceMathOps(userProvidedSrc);

--- a/generators/sculpt.js
+++ b/generators/sculpt.js
@@ -198,7 +198,6 @@ export function replaceMathOps(codeSrc) {
 
 export function sculptToGLSL(userProvidedSrc) {
 	const PI = Math.PI;
-	const TWO_PI = Math.PI * 2;
 	
 	let debug = false;
 	userProvidedSrc = replaceMathOps(userProvidedSrc);
@@ -1259,7 +1258,7 @@ export function sculptToGLSL(userProvidedSrc) {
 		setSpace(vec3(px, s.y, pz));
 		const absC = abs(c);
 		// account for odd number of repeats
-		const diff = step(absC, (repeats/2));
+		const diff = step(absC, (repeats / 2));
 		c = diff*absC + (1-diff)*c;
 		// return radial index
 		return c;


### PR DESCRIPTION
I found that the parameter TAU is the same as TWO_PI and both of them have never been used in sculptToGLSL function, so I remove both of them.