### PR TITLE
print out userProvidedSrc instead

### DIFF
--- a/generators/sculpt.js
+++ b/generators/sculpt.js
@@ -205,7 +205,7 @@ export function sculptToGLSL(userProvidedSrc) {
 	userProvidedSrc = replaceMathOps(userProvidedSrc);
 
 	if (debug) {
-		console.log('tree', tree);
+		console.log('userProvidedSrc', userProvidedSrc);
 	}
 
 	let generatedJSFuncsSource = "";


### PR DESCRIPTION
In debug mode, there would be an error say that parameter `tree` is not found. I believe the original script `console.log('tree', tree)` is to print out the return result in `replaceMathOps` function. So I replace it to `userProvidedSrc` instead.