### PR TITLE
Fix distortion in p5 integration

### DIFF
--- a/targets/p5.js
+++ b/targets/p5.js
@@ -21,7 +21,6 @@ export function toGLSL(source) {
 precision highp float;
 in vec3 aPosition;
 uniform mat4 uModelViewMatrix;
-uniform mat4 uInverseModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 out vec4 worldPos;
 out vec3 sculptureCenter;
@@ -29,11 +28,11 @@ out vec3 cameraPosition;
 void main() {
   vec4 mvPosition = uModelViewMatrix * vec4(aPosition, 1.0);
 
-  mat4 modelMatrix = uModelViewMatrix;
+  mat4 inverseModelViewMatrix = inverse(uModelViewMatrix);
 
   worldPos = vec4(aPosition, 1.);
   sculptureCenter = vec3(0.);
-  cameraPosition = (uInverseModelViewMatrix * vec4(0., 0., 0., 1.0)).xyz;
+  cameraPosition = (inverseModelViewMatrix * vec4(0., 0., 0., 1.0)).xyz;
 
   gl_Position = uProjectionMatrix * mvPosition;
 }
@@ -97,8 +96,6 @@ function createRenderer(target, {
         );
       }
 
-      const inverseModelViewMatrix =
-        new p5.Matrix().invert(_renderer.uMVMatrix)
       const gl = window._renderer.GL;
       const faceCullingEnabled = gl.isEnabled(gl.CULL_FACE);
       const cullFaceMode = gl.getParameter(gl.CULL_FACE_MODE);
@@ -108,10 +105,6 @@ function createRenderer(target, {
       target.push();
       target.noStroke();
       target.shader(output.shader);
-      output.shader.setUniform(
-        'uInverseModelViewMatrix',
-        inverseModelViewMatrix.mat4
-      );
       output.shader.setUniform('time', millis() / 1000);
       output.shader.setUniform('opacity', 1);
       output.shader.setUniform(


### PR DESCRIPTION
Currently, cubes rendered via the p5 integration show spherical distortion:
<img width="281" alt="image" src="https://github.com/shader-park/shader-park-core/assets/5315059/ec1d4b55-e9bb-47e3-952d-8b69fe177133">

This is because the p5 integration was inverting the model view matrix before drawing the sphere that we render Shader Park onto. However, when drawing a sphere, [p5 updates the model view matrix again to apply a scale.](https://github.com/processing/p5.js/blob/36437b3d68bc651b8695a401159eef36aeec5881/src/webgl/p5.RendererGL.Retained.js#L192-L197) The camera information passed to Shader Park does not have this scale, which results in incorrect rays.

I've updated the code to no longer do the matrix inversion in Javascript. This eliminates the need to grab the model view matrix ahead of time, and instead only uses the correct `uMVMatrix` that p5 passes in.

Updated:

<img width="321" alt="image" src="https://github.com/shader-park/shader-park-core/assets/5315059/76dd352e-69a3-4968-b041-53852e825c57">
Live: https://editor.p5js.org/davepagurek/sketches/HM9sUI8Qh
